### PR TITLE
Configure API Gateway response caching on the 'get-cat-by-pawId' endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # An AWS API Gateway response caching example
 
-TODO
+Configuring API Gateway response caching is still a bit of a faff, especially seeing as the [Serverless Framework](https://serverless.com/) doesn't really support beyond what `CloudFormation` does.
+
+I've created this repo because although [Yan's blogpost got me most of the way there](https://hackernoon.com/serverless-1-x-enable-api-gateway-caching-on-request-parameters-894b31762068), I still haven't quite got it working.
+
+When it comes to caching responses in real-world applications, I think it's probable that:
+
+- You'll only want to enable caching on specific endpoints. Typically some endpoints in an API will serve data that is too volatile to cache.
+- You'll only want to enable caching in certain environments, to keep your AWS bills down.
+- You're cache keys will be based on a combination of the URL and the request headers. For example, you may want to make the `Authorization` header part of the cache key, so that responses are cached on a per user basis.
+- You'll probably want to cache responses longer than the default TTL of 5 mimutes (300 seconds).
+
+In this trivial example, I'm trying to cover all of the above:
+
+- The `cat-api` has two endpoints; one endpoint has its responses cached, the other does not.
+- Caching can be enabled in some environments but not others, based on an environment variable.
+- The cached endpoint is localised so in addition to its URL parameter, the `Accept-Language` header forms part of the cache key. This ensures- for example- that users asking for a cat in French do not get served an English translation of the cat cached previously.
+- Responses are cached for 1 hour (3600 seconds), which is the maximum TTL Api Gateway supports.
+
+If you're wondering why I'm using the [serverless-plugin-bind-deployment-id](https://github.com/jacob-meacham/serverless-plugin-bind-deployment-id) plugin, I needed to do this in order to get `Serverless` to deploy the `ApiGatewayStage`. Without it, you get an error.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2423,6 +2423,23 @@
         "yaml-ast-parser": "0.0.34"
       }
     },
+    "serverless-plugin-bind-deployment-id": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-bind-deployment-id/-/serverless-plugin-bind-deployment-id-1.0.1.tgz",
+      "integrity": "sha1-xVdoZwuEFMSzt44eLwN6ijmVwsQ=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
+    },
     "serverless-pseudo-parameters": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "serverless": "^1.30.3",
+    "serverless-plugin-bind-deployment-id": "^1.0.1",
     "serverless-pseudo-parameters": "^2.2.0"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -11,6 +11,7 @@ provider:
 
 plugins:
   - serverless-pseudo-parameters
+  - serverless-plugin-bind-deployment-id
 
 custom:
   stage: ${opt:stage, self:provider.stage}
@@ -39,5 +40,37 @@ functions:
     
 resources:
   Resources:
+    __deployment__:
+      Properties:
+        Description: Deploying the Cat API. Meow.
+    ApiGatewayStage:
+      Type: "AWS::ApiGateway::Stage"
+      Properties:
+        CacheClusterEnabled: ${self:custom.variables.cachingIsEnabled}
+        CacheClusterSize: 0.5
+        MethodSettings:
+          - ResourcePath: "/*"
+            HttpMethod: "*"
+            CachingEnabled: false
+        RestApiId:
+          Ref: ApiGatewayRestApi
+        DeploymentId:
+          Ref: __deployment__
+        StageName: ${self:custom.stage}
+    ApiGatewayMethodCatsPawidVarGet:
+      Properties:
+        HttpMethod: GET
+        #CacheTtlInSeconds: 3600 <-- this is not a valid field; I assume you can set a TTL per endpoint though?
+        RequestParameters:
+          method.request.path.pawId: true
+          method.request.header.Accept-Language: true
+        Integration:
+          RequestParameters:
+            integration.request.path.pawId: method.request.path.pawId
+            integration.request.header.Accept-Language: method.request.header.Accept-Language
+          CacheNamespace: ApiGatewayMethodCatsPawidVarGetCacheNS
+          CacheKeyParameters:
+            - method.request.path.pawId
+            - method.request.header.Accept-Language
     listCatsRole: ${file(security/roles/listCatsRole.yml)}
     getCatRole: ${file(security/roles/getCatRole.yml)}


### PR DESCRIPTION
Hey peeps, I've been trying to configure API Gateway caching on an API at work and it's been driving me bananas, so I thought I'd create a quick example repo to figure out what I'm doing wrong. Hopefully it might  help other people too when I get to the bottom of it.

I've have an API with 2 endpoints:

- `list-all-cats` (caching disabled)
- `get-cat-by-paw-id` (caching enabled)

For the enabled endpoint, the cache key is based on the `pawId` URL parameter and the `Accept-Language` header. I've written a `CloudFormation` template based on what I believe is required but it's not working as expected.

Firstly an API Gateway stage called `__unused_stage__` is being created. I believe this is being created by the `serverless-plugin-bind-deployment-id` plugin I've had to use. Without that plugin, I get an error when deploying the `ApiGatewayStage `. I don't recall having to use this plugin in the past.

<img width="1142" alt="an_unused_stage_is_created" src="https://user-images.githubusercontent.com/619001/45168845-312d7780-b1f4-11e8-9489-124667942689.png">

The deployment succeeds and I can see that caching is enabled on my actual stage:

<img width="1143" alt="caching_is_enabled_on_the_actual_stage" src="https://user-images.githubusercontent.com/619001/45168898-4e624600-b1f4-11e8-8068-25eda82f4683.png">

However, it looks like both endpoints simply inherit the settings from the stage. Given that I have disabled caching across the board, then enabled it on one endpoint only by overriding the settings, I was expecting to see something different to this.

<img width="1039" alt="the_endpoint_without_caching_inherits_from_the_stage" src="https://user-images.githubusercontent.com/619001/45168944-65089d00-b1f4-11e8-85cd-f40c7b72c4ed.png">

<img width="1117" alt="the_endpoint_with_cachiing_inherits_from_the_stage" src="https://user-images.githubusercontent.com/619001/45168975-718cf580-b1f4-11e8-863c-5201062a5816.png">

If anyone has done something similar recently and can tell me what I'm doing wrong, your dinner is on me next week!